### PR TITLE
Improve Async Login to avoid firing in middle of Entity Ticking

### DIFF
--- a/Spigot-Server-Patches/0392-Reduce-sync-loads.patch
+++ b/Spigot-Server-Patches/0392-Reduce-sync-loads.patch
@@ -1,4 +1,4 @@
-From 1f3e0ea68603b51962d92e370949407a4b0e1f6f Mon Sep 17 00:00:00 2001
+From f2de347a5ea40b9cceaaefcf899dfd0f52394a30 Mon Sep 17 00:00:00 2001
 From: Spottedleaf <Spottedleaf@users.noreply.github.com>
 Date: Fri, 19 Jul 2019 03:29:14 -0700
 Subject: [PATCH] Reduce sync loads
@@ -11,7 +11,7 @@ it must be enabled by setting the startup flag -Dpaper.debug-sync-loads=true
 To get a debug log for sync loads, the command is /paper syncloadinfo
 
 diff --git a/src/main/java/com/destroystokyo/paper/PaperCommand.java b/src/main/java/com/destroystokyo/paper/PaperCommand.java
-index af81098784..dfe92780ad 100644
+index af81098784..ddb60e9a48 100644
 --- a/src/main/java/com/destroystokyo/paper/PaperCommand.java
 +++ b/src/main/java/com/destroystokyo/paper/PaperCommand.java
 @@ -1,9 +1,13 @@
@@ -38,6 +38,23 @@ index af81098784..dfe92780ad 100644
  import java.time.LocalDateTime;
  import java.time.format.DateTimeFormatter;
  import java.util.*;
+@@ -28,14 +35,14 @@ public class PaperCommand extends Command {
+     public PaperCommand(String name) {
+         super(name);
+         this.description = "Paper related commands";
+-        this.usageMessage = "/paper [heap | entity | reload | version | debug | chunkinfo]";
++        this.usageMessage = "/paper [heap | entity | reload | version | debug | chunkinfo | syncloadinfo]";
+         this.setPermission("bukkit.command.paper");
+     }
+ 
+     @Override
+     public List<String> tabComplete(CommandSender sender, String alias, String[] args, Location location) throws IllegalArgumentException {
+         if (args.length <= 1)
+-            return getListMatchingLast(args, "heap", "entity", "reload", "version", "debug", "chunkinfo");
++            return getListMatchingLast(args, "heap", "entity", "reload", "version", "debug", "chunkinfo", "syncloadinfo");
+ 
+         switch (args[0].toLowerCase(Locale.ENGLISH))
+         {
 @@ -130,6 +137,9 @@ public class PaperCommand extends Command {
              case "chunkinfo":
                  doChunkInfo(sender, args);

--- a/Spigot-Server-Patches/0452-Do-not-allow-bees-to-load-chunks-for-beehives.patch
+++ b/Spigot-Server-Patches/0452-Do-not-allow-bees-to-load-chunks-for-beehives.patch
@@ -1,11 +1,11 @@
-From 170e421a60923a30f605ff7e963da9a2e6a018dd Mon Sep 17 00:00:00 2001
-From: chickeneer <Paperchickeneer@gmail.com>
+From ae437c7a8fa1c923d90945d464f5de915abb6530 Mon Sep 17 00:00:00 2001
+From: chickeneer <emcchickeneer@gmail.com>
 Date: Tue, 17 Mar 2020 14:18:50 -0500
 Subject: [PATCH] Do not allow bees to load chunks for beehives
 
 
 diff --git a/src/main/java/net/minecraft/server/EntityBee.java b/src/main/java/net/minecraft/server/EntityBee.java
-index c7d79efd..dd1d246a 100644
+index c7d79efdf6..dd1d246aeb 100644
 --- a/src/main/java/net/minecraft/server/EntityBee.java
 +++ b/src/main/java/net/minecraft/server/EntityBee.java
 @@ -315,6 +315,7 @@ public class EntityBee extends EntityAnimal implements EntityBird {
@@ -41,5 +41,5 @@ index c7d79efd..dd1d246a 100644
  
              if (tileentity instanceof TileEntityBeehive) {
 -- 
-2.25.1.windows.1
+2.26.2
 

--- a/Spigot-Server-Patches/0486-Load-Chunks-for-Login-Asynchronously.patch
+++ b/Spigot-Server-Patches/0486-Load-Chunks-for-Login-Asynchronously.patch
@@ -1,11 +1,11 @@
-From 3dc63160ade1b4a3feac971d88fb0b6ecbb5c28e Mon Sep 17 00:00:00 2001
+From 0593226cf73df0cf943f0ddc4090dde945e70265 Mon Sep 17 00:00:00 2001
 From: Aikar <aikar@aikar.co>
 Date: Sun, 19 Apr 2020 04:28:29 -0400
 Subject: [PATCH] Load Chunks for Login Asynchronously
 
 
 diff --git a/src/main/java/net/minecraft/server/Entity.java b/src/main/java/net/minecraft/server/Entity.java
-index 96a47dd1c2..96ebe0b226 100644
+index 324fd07bce..01330045c0 100644
 --- a/src/main/java/net/minecraft/server/Entity.java
 +++ b/src/main/java/net/minecraft/server/Entity.java
 @@ -1382,7 +1382,7 @@ public abstract class Entity implements INamableTileEntity, ICommandListener, Ke
@@ -18,7 +18,7 @@ index 96a47dd1c2..96ebe0b226 100644
  
      public void setPositionRotation(BlockPosition blockposition, float f, float f1) {
 diff --git a/src/main/java/net/minecraft/server/EntityPlayer.java b/src/main/java/net/minecraft/server/EntityPlayer.java
-index 686fd4cbad..079ddc714e 100644
+index a48e113b53..0f9bca8b8b 100644
 --- a/src/main/java/net/minecraft/server/EntityPlayer.java
 +++ b/src/main/java/net/minecraft/server/EntityPlayer.java
 @@ -43,6 +43,7 @@ public class EntityPlayer extends EntityHuman implements ICrafting {
@@ -60,19 +60,37 @@ index f1222fcb2b..28f48f2252 100644
              if (entityplayer != null) {
                  this.g = LoginListener.EnumProtocolState.DELAY_ACCEPT;
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index 7929fcc800..c3710b73af 100644
+index 2e81f3a1d9..8800a8fcf9 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -142,6 +142,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -69,6 +69,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+     private static final Logger LOGGER = LogManager.getLogger();
+     public final NetworkManager networkManager;
+     private final MinecraftServer minecraftServer;
++    Runnable playerJoinReady; // Paper
+     public EntityPlayer player;
+     private int e;
+     private long lastKeepAlive = SystemUtils.getMonotonicMillis(); private void setLastPing(long lastPing) { this.lastKeepAlive = lastPing;}; private long getLastPing() { return this.lastKeepAlive;}; // Paper - OBFHELPER
+@@ -142,6 +143,17 @@ public class PlayerConnection implements PacketListenerPlayIn {
      // CraftBukkit end
  
      public void tick() {
-+        if (!this.player.valid) return; // Paper
++        // Paper start - login async
++        Runnable playerJoinReady = this.playerJoinReady;
++        if (playerJoinReady != null) {
++            this.playerJoinReady = null;
++            playerJoinReady.run();
++        }
++        // Don't tick if not valid (dead), otherwise we load chunks below
++        if (!this.player.valid) {
++            return;
++        }
++        // Paper end
          this.syncPosition();
          this.player.lastX = this.player.locX();
          this.player.lastY = this.player.locY();
 diff --git a/src/main/java/net/minecraft/server/PlayerList.java b/src/main/java/net/minecraft/server/PlayerList.java
-index ec45c30dd3..eaba3cbf06 100644
+index ec45c30dd3..edf9df8c8a 100644
 --- a/src/main/java/net/minecraft/server/PlayerList.java
 +++ b/src/main/java/net/minecraft/server/PlayerList.java
 @@ -52,11 +52,12 @@ public abstract class PlayerList {
@@ -110,7 +128,7 @@ index ec45c30dd3..eaba3cbf06 100644
          if (nbttagcompound == null) entityplayer.moveToSpawn(worldserver); // Paper - only move to spawn on first login, otherwise, stay where you are....
          // CraftBukkit end
  
-@@ -158,6 +164,46 @@ public abstract class PlayerList {
+@@ -158,6 +164,50 @@ public abstract class PlayerList {
          entityplayer.B().a(entityplayer);
          this.sendScoreboard(worldserver.getScoreboard(), entityplayer);
          this.server.invalidatePingSample();
@@ -119,8 +137,12 @@ index ec45c30dd3..eaba3cbf06 100644
 +        int chunkX = loc.getBlockX() >> 4;
 +        int chunkZ = loc.getBlockZ() >> 4;
 +        worldserver.getChunkProvider().getTickingChunkAsync(chunkX, chunkZ, (chunk -> { // use ticking - as it has at least 1 neighbours loaded
-+            postChunkLoadJoin(entityplayer, finalWorldserver, networkmanager, playerconnection, nbttagcompound, networkmanager.getSocketAddress().toString(),
-+                lastKnownName);
++            playerconnection.playerJoinReady = () -> {
++                postChunkLoadJoin(
++                    entityplayer, finalWorldserver, networkmanager, playerconnection,
++                    nbttagcompound, networkmanager.getSocketAddress().toString(), lastKnownName
++                );
++            };
 +        }));
 +        // boost the priorities
 +        worldserver.asyncChunkTaskManager.raisePriority(chunkX, chunkZ, com.destroystokyo.paper.io.PrioritizedTaskQueue.HIGHEST_PRIORITY);
@@ -157,7 +179,23 @@ index ec45c30dd3..eaba3cbf06 100644
          ChatMessage chatmessage;
  
          if (entityplayer.getProfile().getName().equalsIgnoreCase(s)) {
-@@ -388,6 +434,7 @@ public abstract class PlayerList {
+@@ -216,7 +266,6 @@ public abstract class PlayerList {
+         }
+         entityplayer.sentListPacket = true;
+         entityplayer.supressTrackerForLogin = false; // Paper
+-        ((WorldServer)entityplayer.world).getChunkProvider().playerChunkMap.addEntity(entityplayer); // Paper - track entity now
+         // CraftBukkit end
+ 
+         entityplayer.playerConnection.sendPacket(new PacketPlayOutEntityMetadata(entityplayer.getId(), entityplayer.datawatcher, true)); // CraftBukkit - BungeeCord#2321, send complete data to self on spawn
+@@ -243,6 +292,7 @@ public abstract class PlayerList {
+         }
+ 
+         // Paper start - move vehicle into method so it can be called above - short circuit around that code
++        ((WorldServer)entityplayer.world).getChunkProvider().playerChunkMap.addEntity(entityplayer); // track entity now
+         onPlayerJoinFinish(entityplayer, worldserver, s1);
+     }
+     private void mountSavedVehicle(EntityPlayer entityplayer, WorldServer worldserver, NBTTagCompound nbttagcompound) {
+@@ -388,6 +438,7 @@ public abstract class PlayerList {
  
      protected void savePlayerFile(EntityPlayer entityplayer) {
          if (!entityplayer.getBukkitEntity().isPersistent()) return; // CraftBukkit
@@ -165,7 +203,7 @@ index ec45c30dd3..eaba3cbf06 100644
          this.playerFileData.save(entityplayer);
          ServerStatisticManager serverstatisticmanager = (ServerStatisticManager) entityplayer.getStatisticManager(); // CraftBukkit
  
-@@ -412,7 +459,7 @@ public abstract class PlayerList {
+@@ -412,7 +463,7 @@ public abstract class PlayerList {
          org.bukkit.craftbukkit.event.CraftEventFactory.handleInventoryCloseEvent(entityplayer, org.bukkit.event.inventory.InventoryCloseEvent.Reason.DISCONNECT); // Paper
  
          PlayerQuitEvent playerQuitEvent = new PlayerQuitEvent(cserver.getPlayer(entityplayer), "\u00A7e" + entityplayer.getName() + " left the game");
@@ -174,7 +212,7 @@ index ec45c30dd3..eaba3cbf06 100644
          entityplayer.getBukkitEntity().disconnect(playerQuitEvent.getQuitMessage());
  
          if (server.isMainThread()) entityplayer.playerTick();// SPIGOT-924 // Paper - don't tick during emergency shutdowns (Watchdog)
-@@ -464,6 +511,13 @@ public abstract class PlayerList {
+@@ -464,6 +515,13 @@ public abstract class PlayerList {
              // this.p.remove(uuid);
              // CraftBukkit end
          }
@@ -188,7 +226,7 @@ index ec45c30dd3..eaba3cbf06 100644
  
          // CraftBukkit start
          //  this.sendAll(new PacketPlayOutPlayerInfo(EnumPlayerInfoAction.REMOVE_PLAYER, new EntityPlayer[]{entityplayer}));
-@@ -481,7 +535,7 @@ public abstract class PlayerList {
+@@ -481,7 +539,7 @@ public abstract class PlayerList {
          cserver.getScoreboardManager().removePlayer(entityplayer.getBukkitEntity());
          // CraftBukkit end
  
@@ -197,7 +235,7 @@ index ec45c30dd3..eaba3cbf06 100644
      }
  
      // CraftBukkit start - Whole method, SocketAddress to LoginListener, added hostname to signature, return EntityPlayer
-@@ -500,6 +554,13 @@ public abstract class PlayerList {
+@@ -500,6 +558,13 @@ public abstract class PlayerList {
                  list.add(entityplayer);
              }
          }
@@ -212,5 +250,5 @@ index ec45c30dd3..eaba3cbf06 100644
          Iterator iterator = list.iterator();
  
 -- 
-2.25.1
+2.26.2
 

--- a/Spigot-Server-Patches/0488-Allow-sleeping-players-to-float.patch
+++ b/Spigot-Server-Patches/0488-Allow-sleeping-players-to-float.patch
@@ -1,4 +1,4 @@
-From faa398e6e6084254ca85e533575edf79f605223c Mon Sep 17 00:00:00 2001
+From 12534ede5c4556d34e7e207fb7970b92b7ead475 Mon Sep 17 00:00:00 2001
 From: Mariell Hoversholm <proximyst@proximyst.com>
 Date: Sun, 19 Apr 2020 12:25:20 +0200
 Subject: [PATCH] Allow sleeping players to float
@@ -9,10 +9,10 @@ their position to the ground/exit location when entering the bed, resulting in
 the server believing they're still in the air.
 
 diff --git a/src/main/java/net/minecraft/server/PlayerConnection.java b/src/main/java/net/minecraft/server/PlayerConnection.java
-index c3710b73af..b62535ba04 100644
+index 8800a8fcf9..38ec22f4c0 100644
 --- a/src/main/java/net/minecraft/server/PlayerConnection.java
 +++ b/src/main/java/net/minecraft/server/PlayerConnection.java
-@@ -151,7 +151,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
+@@ -162,7 +162,7 @@ public class PlayerConnection implements PacketListenerPlayIn {
          this.player.setLocation(this.l, this.m, this.n, this.player.yaw, this.player.pitch);
          ++this.e;
          this.processedMovePackets = this.receivedMovePackets;
@@ -22,5 +22,5 @@ index c3710b73af..b62535ba04 100644
                  PlayerConnection.LOGGER.warn("{} was kicked for floating too long!", this.player.getDisplayName().getString());
                  this.disconnect(com.destroystokyo.paper.PaperConfig.flyingKickPlayerMessage); // Paper - use configurable kick message
 -- 
-2.25.1
+2.26.2
 


### PR DESCRIPTION
If a sync load was triggered, it would process pending join events,
causing them to be added to the world in the middle of the entity ticking
process.

This caused their add to be queued instead of immediate, causing
"Illegal Tracking" errors.

This schedules it to fire at the players next Connection Tick, which
is exactly where this entire process use to run anyways.

Also added missing tab complete and syntax for syncloadinfo debug command